### PR TITLE
Using consistent channel ordering for FilterNode

### DIFF
--- a/Plugins/FilterNode/FilterNode.cpp
+++ b/Plugins/FilterNode/FilterNode.cpp
@@ -204,9 +204,8 @@ void FilterNode::process (AudioBuffer<float>& buffer)
             
             const uint16 streamId = stream->getStreamId();
             const uint32 numSamples = getNumSamplesInBlock(streamId);
-
-            for (auto localChannelIndex : *((*stream)["Channels"].getArray()))
-            {
+            int num_channels = stream->getChannelCount();
+            for (int localChannelIndex = 0; localChannelIndex < num_channels; ++localChannelIndex) {
                 int globalChannelIndex = getGlobalChannelIndex(stream->getStreamId(), (int) localChannelIndex);
 
                 float* ptr = buffer.getWritePointer(globalChannelIndex);


### PR DESCRIPTION
Weirdly, when loading FilterNode from XML when channels/streams change (like for UG3 interface), it somehow gets "stale" data and filters a subset of channels incorrectly. The filters in FilterNode are constructed with channel indices from 0...num_channels - 1, but during process() it's different. Making them the same fixes it.

@admunkucsd FYI