### PR TITLE
Add seperate Event for Reference Samples

### DIFF
--- a/Plugins/LfpDisplayNode/Tests/LfpDisplayNodeTests.cpp
+++ b/Plugins/LfpDisplayNode/Tests/LfpDisplayNodeTests.cpp
@@ -186,8 +186,7 @@ protected:
             current_sample_index,
             0,
             buffer.getNumSamples(),
-            0,
-            current_sample_index);
+            0);
         MidiBuffer eventBuffer;
         eventBuffer.addEvent(data, dataSize, 0);
 

--- a/Source/Processors/DataThreads/DataBuffer.cpp
+++ b/Source/Processors/DataThreads/DataBuffer.cpp
@@ -69,7 +69,7 @@ int DataBuffer::addToBuffer (float* data,
                              uint64* eventCodes,
                              int numItems,
                              int chunkSize,
-                             int timestampSampleIndex)
+                             std::optional<int64> timestampSampleIndex)
 {
     int startIndex1, blockSize1, startIndex2, blockSize2;
 
@@ -123,7 +123,7 @@ int DataBuffer::readAllFromBuffer (AudioBuffer<float>& data,
                                    double* blockTimestamp,
                                    uint64* eventCodes,
                                    int maxSize,
-                                   int64* timestampSampleIndex,
+                                   std::optional<int64>* timestampSampleIndex,
                                    int dstStartChannel,
                                    int numChannels)
 {
@@ -151,7 +151,7 @@ int DataBuffer::readAllFromBuffer (AudioBuffer<float>& data,
         memcpy (blockSampleNumber, sampleNumberBuffer + startIndex1, 8);
         memcpy (blockTimestamp, timestampBuffer + startIndex1, 8);
         memcpy (eventCodes, eventCodeBuffer + startIndex1, blockSize1 * 8);
-        memcpy (timestampSampleIndex, timestampSampleBuffer + startIndex1, 8);
+        memcpy (timestampSampleIndex, timestampSampleBuffer + startIndex1, sizeof(std::optional<int64>));
 
     }
     else

--- a/Source/Processors/DataThreads/DataBuffer.h
+++ b/Source/Processors/DataThreads/DataBuffer.h
@@ -26,6 +26,7 @@
 #include "../../../JuceLibraryCode/JuceHeader.h"
 #include "../PluginManager/OpenEphysPlugin.h"
 
+#include <optional>
 
 /**
     Manages reading and writing data to a circular buffer.
@@ -66,7 +67,7 @@ public:
                      uint64* eventCodes,
                      int numItems,
                      int chunkSize=1,
-                     int timestampSampleIndex = 0);
+                     std::optional<int64> timestampSampleIndex = std::nullopt);
 
     /** Returns the number of samples currently available in the buffer.*/
     int getNumSamples() const;
@@ -77,7 +78,7 @@ public:
                            double* timestamps,
                            uint64* eventCodes,
                            int maxSize,
-                           int64* timestampSampleIndex,
+                           std::optional<int64>* timestampSampleIndex,
                            int dstStartChannel = 0,
                            int numChannels = -1);
 
@@ -92,7 +93,7 @@ private:
     HeapBlock<int64> sampleNumberBuffer;
     HeapBlock<double> timestampBuffer;
     HeapBlock<uint64> eventCodeBuffer;
-    HeapBlock<int64> timestampSampleBuffer;
+    HeapBlock<std::optional<int64>> timestampSampleBuffer;
 
 
 	int64 lastSampleNumber;

--- a/Source/Processors/Events/Event.cpp
+++ b/Source/Processors/Events/Event.cpp
@@ -204,10 +204,9 @@ size_t SystemEvent::fillTimestampAndSamplesData(HeapBlock<char>& data,
 	int64 startSampleForBlock,
     double startTimestampForBlock,
 	uint32 nSamplesInBlock,
-	int64 processStartTime,
-    int64 sampleIndexOfTimestamp)
+	int64 processStartTime)
 {
-	const int eventSize = EVENT_BASE_SIZE + 4 + 8 + 8;
+	const int eventSize = EVENT_BASE_SIZE + 4 + 8;
 	data.malloc(eventSize);
 	data[0] = SYSTEM_EVENT;													 // 1 byte
 	data[1] = TIMESTAMP_AND_SAMPLES;										 // 1 byte
@@ -219,8 +218,26 @@ size_t SystemEvent::fillTimestampAndSamplesData(HeapBlock<char>& data,
     *reinterpret_cast<double*>(data.getData() + 16) = startTimestampForBlock;// 8 bytes
 	*reinterpret_cast<uint32*>(data.getData() + EVENT_BASE_SIZE) = nSamplesInBlock;		 // 8 bytes
 	*reinterpret_cast<int64*>(data.getData() + EVENT_BASE_SIZE + 4) = processStartTime; // 8 bytes
-    *reinterpret_cast<int64*>(data.getData() + EVENT_BASE_SIZE + 12) = sampleIndexOfTimestamp; // 8 byte
 	return eventSize;
+}
+
+size_t SystemEvent::fillReferenceSampleEvent(HeapBlock<char>& data,
+    const GenericProcessor* proc,
+    uint16 streamId,
+    int64 referenceSampleIndex,
+    double referenceSampleTimestamp)
+{
+    const int eventSize = EVENT_BASE_SIZE;
+    data.malloc(eventSize);
+    data[0] = SYSTEM_EVENT;                                                     // 1 byte
+    data[1] = REFERENCE_SAMPLE;                                                 // 1 byte
+    *reinterpret_cast<uint16*>(data.getData() + 2) = proc->getNodeId();         // 2 bytes
+    *reinterpret_cast<uint16*>(data.getData() + 4) = streamId;                 // 2 bytes
+    data[6] = 0;                                                             // 1 byte
+    data[7] = 0;                                                             // 1 byte
+    *reinterpret_cast<int64*>(data.getData() + 8) = referenceSampleIndex;     // 8 bytes
+    *reinterpret_cast<double*>(data.getData() + 16) = referenceSampleTimestamp;// 8 bytes
+    return eventSize;
 }
 
 size_t SystemEvent::fillTimestampSyncTextData(

--- a/Source/Processors/Events/Event.h
+++ b/Source/Processors/Events/Event.h
@@ -220,7 +220,10 @@ public:
 		PARAMETER_CHANGE = 2,
 
 		// Special text event sent by Source Processors at the start of recording
-		TIMESTAMP_SYNC_TEXT = 3
+		TIMESTAMP_SYNC_TEXT = 3,
+        
+        // Indicates reference sample information for each incoming data buffer
+        REFERENCE_SAMPLE = 4
 
 	};
 
@@ -231,8 +234,13 @@ public:
 		int64 startSampleForBlock,
         double timestamp,
 		uint32 nSamplesInBlock,
-		int64 processStartTime,
-        int64 sampleIndexOfTimestamp);
+		int64 processStartTime);
+    
+    static size_t fillReferenceSampleEvent(HeapBlock<char>& data,
+        const GenericProcessor* proc,
+        uint16 streamId,
+        int64 referenceSampleIndex,
+        double referenceSampleTimestamp);
 		
 	/* Create a TIMESTAMP_SYNC_TEXT event */
 	static size_t fillTimestampSyncTextData(HeapBlock<char>& data, 

--- a/Source/Processors/FileReader/FileReader.cpp
+++ b/Source/Processors/FileReader/FileReader.cpp
@@ -549,7 +549,9 @@ void FileReader::process(AudioBuffer<float>& buffer)
                                 samplesNeededPerBuffer);
     }
 
-    setTimestampAndSamples(totalSamplesAcquired, Time::currentTimeMillis()/1e3, samplesNeededPerBuffer, dataStreams[0]->getStreamId(), totalSamplesAcquired); //TODO: Look at this
+    setTimestampAndSamples(totalSamplesAcquired, Time::currentTimeMillis()/1e3, samplesNeededPerBuffer, dataStreams[0]->getStreamId()); //TODO: Look at this
+    
+    setReferenceSample(dataStreams[0]->getStreamId(), Time::currentTimeMillis()/1e3, totalSamplesAcquired);
 
     int64 start = totalSamplesAcquired;
 

--- a/Source/Processors/GenericProcessor/GenericProcessor.h
+++ b/Source/Processors/GenericProcessor/GenericProcessor.h
@@ -48,6 +48,7 @@
 #include <map>
 #include <unordered_map>
 #include <limits>
+#include <optional>
 
 class EditorViewport;
 class DataViewport;
@@ -511,14 +512,20 @@ protected:
     
     /** Used to get the sample index for the current timestamp for a given stream*/
     int64 getTimestampSampleIndexForBlock(uint16 streamId) const;
+    
+    std::optional<std::pair<int64, double>> getReferenceSampleForBlock(uint16 streamId);
 
 
 	/** Used to set the timestamp for a given buffer, for a given DataStream. */
 	void setTimestampAndSamples(int64 startSampleForBlock,
                                 double startTimestampForBlock,
                                 uint32 nSamples,
-                                uint16 streamId,
-                                int64  sampleIndexOfTimestamp);
+                                uint16 streamId);
+    
+    void setReferenceSample(uint16 streamId,
+                            double timestamp,
+                            int64 sampleIndex);
+    
     
     // --------------------------------------------
     //     CHANNEL INDEXING
@@ -676,8 +683,9 @@ private:
     /** Map between stream IDs and start time of process callbacks. */
     std::map<uint16, int64> processStartTimes;
     
-    /** Map between stream IDs and the sample index of buffer timestamp. */
-    std::map<uint16, int64> timestampSampleIndexForBlock;
+    
+    /** Map between stream IDs and  reference samples */
+    std::map<uint16, std::optional<std::pair<int64, double>>> referenceSamplesForBlock;
 
     /** First software timestamp of process() callback. */
 	juce::int64 m_initialProcessTime;

--- a/Source/Processors/SourceNode/SourceNode.cpp
+++ b/Source/Processors/SourceNode/SourceNode.cpp
@@ -330,8 +330,11 @@ void SourceNode::process(AudioBuffer<float>& buffer)
 		setTimestampAndSamples(sampleNumber,
                                timestamp,
                                nSamples,
-                               dataStreams[streamIdx]->getStreamId(),
-                               timestampSampleIndex);
+                               dataStreams[streamIdx]->getStreamId());
+        
+        if(timestampSampleIndex.has_value()) {
+            setReferenceSample(dataStreams[streamIdx]->getStreamId(), timestamp, timestampSampleIndex.value());
+        }
 
 		if (eventChannels[streamIdx])
 		{

--- a/Source/Processors/SourceNode/SourceNode.h
+++ b/Source/Processors/SourceNode/SourceNode.h
@@ -121,7 +121,7 @@ private:
 
     int64 sampleNumber = 0;
     double timestamp = -1.0;
-    int64 timestampSampleIndex = 0;
+    std::optional<int64> timestampSampleIndex;
 
     OwnedArray<MemoryBlock> eventCodeBuffers;
 	Array<uint64> eventStates;

--- a/TestHelpers/include/TestFixtures.h
+++ b/TestHelpers/include/TestFixtures.h
@@ -75,6 +75,17 @@ public:
 
         // Refresh everything
         processor_graph->updateSettings(sn, false);
+    
+    }
+
+    ~ProcessorTester() {
+        control_panel = nullptr;
+        processor_graph = nullptr;
+        audio_component = nullptr;
+
+        AccessClass::clearAccessClassStateForTesting();
+        DeletedAtShutdown::deleteAll();
+        MessageManager::deleteInstance();
     }
 
     /**
@@ -167,8 +178,7 @@ public:
                 // NOTE: this timestamp is actually ignored in the current implementation?
                 0,
                 buffer.getNumSamples(),
-                0,
-                current_sample_index);
+                0);
             eventBuffer.addEvent(data, dataSize, 0);
 
             if (maybe_ttl_event != nullptr) {


### PR DESCRIPTION
-Add optional int field to `addToDataBuffer` for reference sample indexes
-Add `SystemEvent::ReferenceSample` to pass reference sample data through `MidiBuffer`